### PR TITLE
fix path for buttons

### DIFF
--- a/Button/buttons.go
+++ b/Button/buttons.go
@@ -27,7 +27,7 @@ const (
 )
 
 func findFilename() string {
-	filename := "/dev/input/by-path/platform-gpio-keys.0-event"
+	filename := "/dev/input/by-path/platform-gpio_keys-event"
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		log.Fatal("Cannot find keys file")


### PR DESCRIPTION
Right now this error crops up:

```
robot@ev3dev:~$ gocode/bin/GoEV3  

What would you like to test? Press Escape to exit.
[X] Touch sensor and sound
[ ] Ultrasonic sensor
[ ] Infrared sensor
[ ] Color sensor
[ ] Speech and brick buttons
[ ] Motors
[ ] LEDs

2021/08/01 12:15:32 Cannot find keys file
```

Caused by the same issue [here](https://github.com/ev3dev/ev3dev/issues/957#issuecomment-328328952) which was fixed [the same way](https://github.com/ev3dev/ev3dev-lang/pull/181/files)

